### PR TITLE
fix: workspace picker escape falls back to current file directory

### DIFF
--- a/src/workspaces.ts
+++ b/src/workspaces.ts
@@ -61,8 +61,8 @@ export default async function getWorkspaceUri(
 		if (chosen) {
 			workspaceUri = chosen.uri;
 		} else {
-			// Otherwise we just default to whatever the first workspace is.
-			workspaceUri = workspace.workspaceFolders[0].uri;
+			// Otherwise fall back to the current file's directory.
+			workspaceUri = Uri.file(def);
 		}
 	}
 	// return it all.


### PR DESCRIPTION


---
**Stack**:
- #19
- #18
- #17
- #16 ⬅
- #15
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*